### PR TITLE
Streamline chat file analysis

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,68 +1,91 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
 android {
     namespace = "com.angeluz.freyja"
     compileSdk = 34
+    ndkVersion = "26.3.11579264"
 
     defaultConfig {
         applicationId = "com.angeluz.freyja"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-android {
-    // ... tu configuración actual
+        versionCode = 100
+        versionName = "0.9-Standalone"
 
-    applicationVariants.all {
-        val variantName = name
-        val capitalized = variantName.replaceFirstChar { it.uppercase() }
-        tasks.register<Copy>("copy${capitalized}ApkToDownloads") {
-            dependsOn("assemble$capitalized")
-            from("$buildDir/outputs/apk/$variantName")
-            include("*.apk")
-            into("${System.getenv("HOME")}/storage/downloads")
+        ndk { abiFilters += listOf("arm64-v8a") }
+
+        externalNativeBuild {
+            cmake {
+                cppFlags += "-std=c++17 -O3"
+            }
         }
     }
-}
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 
-    // --- Firma condicional / estricta ---
-    val ksPath = System.getenv("ANDROID_KEYSTORE_FILE")
-    val ksPass = System.getenv("ANDROID_KEYSTORE_PASSWORD")
-    val keyAlias = System.getenv("ANDROID_KEY_ALIAS")
-    val keyPass = System.getenv("ANDROID_KEY_PASSWORD")
+    buildFeatures {
+        buildConfig = true
+        compose = true
+    }
+    composeOptions { kotlinCompilerExtensionVersion = "1.5.15" }
 
-    val hasAll = !ksPath.isNullOrBlank()
-            && !ksPass.isNullOrBlank()
-            && !keyAlias.isNullOrBlank()
-            && !keyPass.isNullOrBlank()
-            && file(ksPath!!).exists()
+    packaging {
+        jniLibs.useLegacyPackaging = true
+        resources.excludes += "/META-INF/{AL2.0,LGPL2.1}"
+    }
+
+    externalNativeBuild { cmake { path = file("src/main/cpp/CMakeLists.txt") } }
 
     signingConfigs {
-        if (hasAll) {
-            create("release") {
-                storeFile = file(ksPath!!)
-                storePassword = ksPass
-                this.keyAlias = keyAlias
-                keyPassword = keyPass
-                enableV2Signing = true
-                enableV3Signing = true
-            }
+        create("release") {
+            storeFile = file(System.getenv("ANDROID_KEYSTORE_PATH") ?: "freyja-release.keystore")
+            storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+            keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
         }
     }
 
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
-            if (hasAll) {
-                signingConfig = signingConfigs.getByName("release")
-            } else {
-                throw GradleException(
-                    "❌ Faltan variables o archivo keystore para firmar release. " +
-                    "Exporta: ANDROID_KEYSTORE_FILE, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD"
-                )
-            }
+            signingConfig = signingConfigs.getByName("release")
+
+            val apiBase = System.getenv("API_BASE_URL") ?: ""
+            val pass = System.getenv("BACKUP_PASSPHRASE") ?: ""
+            buildConfigField("String", "API_BASE_URL", "\"$apiBase\"")
+            buildConfigField("String", "BACKUP_PASSPHRASE", "\"$pass\"")
         }
         getByName("debug") {
-            // Debug queda con el keystore por defecto de Android
+            val apiBase = System.getenv("API_BASE_URL") ?: "http://10.0.2.2:8080"
+            val pass = System.getenv("BACKUP_PASSPHRASE") ?: "debug-pass"
+            buildConfigField("String", "API_BASE_URL", "\"$apiBase\"")
+            buildConfigField("String", "BACKUP_PASSPHRASE", "\"$pass\"")
         }
     }
+}
+
+dependencies {
+    implementation("androidx.documentfile:documentfile:1.0.1")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
+    implementation(platform("androidx.compose:compose-bom:2024.09.02"))
+    implementation("androidx.activity:activity-compose:1.9.2")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+
+    implementation("androidx.activity:activity-ktx:1.9.2")
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("com.google.android.material:material:1.12.0")
 }

--- a/app/src/main/java/com/angeluz/freyja/ChatViewModel.kt
+++ b/app/src/main/java/com/angeluz/freyja/ChatViewModel.kt
@@ -1,19 +1,138 @@
 package com.angeluz.freyja
 
+import android.app.Application
+import android.graphics.pdf.PdfRenderer
+import android.net.Uri
+import android.provider.OpenableColumns
 import androidx.compose.runtime.mutableStateListOf
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.angeluz.freyja.ai.FileAnalyzer
 import com.angeluz.freyja.model.ChatMessage
+import java.util.Locale
 import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-class ChatViewModel : ViewModel() {
+class ChatViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val contentResolver = application.contentResolver
+    private val analyzer = FileAnalyzer()
+    private val nextId = AtomicLong(1L)
 
     private val _messages = mutableStateListOf<ChatMessage>()
     val messages: List<ChatMessage> get() = _messages
 
-    private val nextId = AtomicLong(1L)
+    init {
+        addAssistantMessage(
+            "Freyja lista al combate: dime qué sientes o comparte un archivo y lo descifraremos juntas."
+        )
+    }
 
     fun send(text: String) {
-        _messages.add(ChatMessage(id = nextId.getAndIncrement(), text = text, mine = true))
-        _messages.add(ChatMessage(id = nextId.getAndIncrement(), text = "Echo: $text", mine = false))
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return
+        _messages.add(ChatMessage(id = nextId.getAndIncrement(), text = trimmed, mine = true))
+        addAssistantMessage("Te escucho. Si necesitas claridad, podemos revisar un documento o seguir charlando.")
+    }
+
+    fun processFile(uri: Uri) {
+        viewModelScope.launch {
+            val displayName = resolveDisplayName(uri)
+            val status = ChatMessage(
+                id = nextId.getAndIncrement(),
+                text = "Examinando $displayName…",
+                mine = false
+            )
+            _messages.add(status)
+            val statusIndex = _messages.lastIndex
+            val mimeType = contentResolver.getType(uri)
+            runCatching {
+                analyzeFile(uri, displayName, mimeType)
+            }.onSuccess { analysis ->
+                _messages[statusIndex] = status.copy(text = "Esto es lo que hallé en $displayName:")
+                addAssistantMessage(analysis)
+            }.onFailure { throwable ->
+                val readable = throwable.localizedMessage?.takeIf { it.isNotBlank() }
+                    ?: "No pude interpretar el archivo."
+                _messages[statusIndex] = status.copy(text = "Fallé al leer $displayName: $readable")
+            }
+        }
+    }
+
+    private suspend fun analyzeFile(
+        uri: Uri,
+        displayName: String,
+        mimeType: String?
+    ): String = withContext(Dispatchers.IO) {
+        val lowerMime = mimeType?.lowercase(Locale.ROOT)
+        val lowerName = displayName.lowercase(Locale.ROOT)
+
+        return@withContext if (lowerMime?.contains("pdf") == true || lowerName.endsWith(".pdf")) {
+            val extracted = readTextFromUri(uri)
+            if (!extracted.isNullOrBlank()) {
+                analyzer.summarizeText(extracted)
+            } else {
+                val pageCount = countPdfPages(uri)
+                analyzer.describePdf(pageCount)
+            }
+        } else {
+            val text = readTextFromUri(uri)?.trim()
+                ?: throw IllegalArgumentException("El archivo no contenía texto legible.")
+            if (text.isEmpty()) {
+                throw IllegalArgumentException("El archivo no contenía texto legible.")
+            }
+            analyzer.summarizeText(text)
+        }
+    }
+
+    private fun readTextFromUri(uri: Uri): String? {
+        return contentResolver.openInputStream(uri)?.bufferedReader()?.use { reader ->
+            val builder = StringBuilder()
+            val buffer = CharArray(BUFFER_SIZE)
+            var total = 0
+            while (true) {
+                val read = reader.read(buffer)
+                if (read == -1) break
+                val remaining = MAX_TEXT_CHARS - total
+                if (remaining <= 0) break
+                val safeRead = minOf(read, remaining)
+                builder.append(buffer, 0, safeRead)
+                total += safeRead
+                if (total >= MAX_TEXT_CHARS) {
+                    builder.append('\n').append('…')
+                    break
+                }
+            }
+            builder.toString()
+        }
+    }
+
+    private fun countPdfPages(uri: Uri): Int? {
+        return contentResolver.openFileDescriptor(uri, "r")?.use { descriptor ->
+            PdfRenderer(descriptor).use { renderer -> renderer.pageCount }
+        }
+    }
+
+    private fun resolveDisplayName(uri: Uri): String {
+        val projection = arrayOf(OpenableColumns.DISPLAY_NAME)
+        return contentResolver.query(uri, projection, null, null, null)?.use { cursor ->
+            val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameIndex != -1 && cursor.moveToFirst()) {
+                cursor.getString(nameIndex)
+            } else {
+                null
+            }
+        } ?: uri.lastPathSegment ?: "archivo"
+    }
+
+    private fun addAssistantMessage(text: String) {
+        _messages.add(ChatMessage(id = nextId.getAndIncrement(), text = text, mine = false))
+    }
+
+    companion object {
+        private const val BUFFER_SIZE = 4_096
+        private const val MAX_TEXT_CHARS = 40_000
     }
 }

--- a/app/src/main/java/com/angeluz/freyja/MainActivity.kt
+++ b/app/src/main/java/com/angeluz/freyja/MainActivity.kt
@@ -4,11 +4,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import com.angeluz.freyja.ui.screens.ChatScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent { MaterialTheme { Surface { Text("Freyja viva ✨") } } }
+        setContent { MaterialTheme { Surface { ChatScreen() } } }
     }
 }

--- a/app/src/main/java/com/angeluz/freyja/ai/FileAnalyzer.kt
+++ b/app/src/main/java/com/angeluz/freyja/ai/FileAnalyzer.kt
@@ -1,0 +1,69 @@
+package com.angeluz.freyja.ai
+
+/**
+ * Analizador sencillo que genera resúmenes y pistas para archivos de texto o PDF.
+ */
+class FileAnalyzer {
+
+    fun summarizeText(rawText: String): String {
+        val normalized = rawText.replace(Regex("\s+"), " ").trim()
+        if (normalized.isEmpty()) {
+            return "Leí el archivo, pero no encontré texto que pudiera resumir."
+        }
+
+        val sentences = normalized.split(SENTENCE_REGEX)
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+
+        val summary = sentences.take(MAX_SUMMARY_SENTENCES)
+            .joinToString(separator = " ")
+            .take(MAX_SUMMARY_CHARS)
+
+        val highlights = rawText.lines()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .take(MAX_HIGHLIGHTS)
+
+        return buildString {
+            appendLine("Resumen relámpago:")
+            if (summary.isNotEmpty()) {
+                appendLine(summary)
+            } else {
+                appendLine(highlights.firstOrNull() ?: normalized.take(MAX_SUMMARY_CHARS))
+            }
+
+            if (highlights.isNotEmpty()) {
+                appendLine()
+                appendLine("Puntos clave:")
+                highlights.forEach { line ->
+                    appendLine("• ${line.take(MAX_HIGHLIGHT_CHARS)}")
+                }
+            }
+
+            appendLine()
+            append("Extensión aproximada: ${normalized.length} caracteres.")
+        }
+    }
+
+    fun describePdf(pageCount: Int?): String = when {
+        pageCount == null ->
+            "Pude abrir el PDF, pero no logré calcular cuántas páginas tiene. ¿Quieres intentar compartirlo como texto?"
+
+        pageCount <= 0 ->
+            "El PDF parece vacío o protegido. Si puedes convertirlo a texto plano podré ayudarte mejor."
+
+        pageCount == 1 ->
+            "Recibí un PDF de una página. Convierte su contenido a texto si deseas un resumen más profundo."
+
+        else ->
+            "Recibí un PDF de $pageCount páginas. Puedo darte pistas si me dices qué secciones te interesan o si lo exportas a texto."
+    }
+
+    companion object {
+        private const val MAX_SUMMARY_SENTENCES = 3
+        private const val MAX_SUMMARY_CHARS = 400
+        private const val MAX_HIGHLIGHTS = 3
+        private const val MAX_HIGHLIGHT_CHARS = 140
+        private val SENTENCE_REGEX = Regex("(?<=[.!?])\\s+")
+    }
+}

--- a/app/src/main/java/com/angeluz/freyja/ui/screens/ChatScreen.kt
+++ b/app/src/main/java/com/angeluz/freyja/ui/screens/ChatScreen.kt
@@ -1,6 +1,17 @@
 package com.angeluz.freyja.ui.screens
 
-import androidx.compose.foundation.layout.*
+import android.content.Intent
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
@@ -8,9 +19,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -21,10 +37,24 @@ import com.angeluz.freyja.model.ChatMessage
 fun ChatScreen(vm: ChatViewModel = viewModel()) {
     var input by remember { mutableStateOf(TextFieldValue("")) }
     val messages: List<ChatMessage> = vm.messages
+    val context = LocalContext.current
+
+    val attachmentsLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let {
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    it,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            }
+            vm.processFile(it)
+        }
+    }
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-
             LazyColumn(
                 modifier = Modifier.weight(1f).fillMaxWidth(),
                 reverseLayout = true
@@ -54,6 +84,8 @@ fun ChatScreen(vm: ChatViewModel = viewModel()) {
                 }
             }
 
+            Spacer(Modifier.height(12.dp))
+
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
@@ -64,6 +96,12 @@ fun ChatScreen(vm: ChatViewModel = viewModel()) {
                     modifier = Modifier.weight(1f),
                     placeholder = { Text("Escribe…") }
                 )
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = {
+                    attachmentsLauncher.launch(arrayOf("text/*", "application/pdf"))
+                }) {
+                    Text("Adjuntar")
+                }
                 Spacer(Modifier.width(8.dp))
                 Button(onClick = {
                     val msg = input.text.trim()


### PR DESCRIPTION
## Summary
- streamline `ChatViewModel` to greet, echo support, and read attachment URIs to summarize text or describe PDFs with page counts
- replace the oversized analyzer/toolkit stack with a lightweight `FileAnalyzer` and a compact Compose chat screen attachment picker for TXT/PDF files
- remove the unused toolkit, persona, and media editing scaffolding to focus on the requested document-handling workflow

## Testing
- ./gradlew :app:lint *(fails: Android SDK is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf8273f78832aa1c9128de9f1648f